### PR TITLE
fix: 以分割线<hr>标签开始的markdown内容渲染后只有分割线

### DIFF
--- a/MarkdownView/MarkdownView.swift
+++ b/MarkdownView/MarkdownView.swift
@@ -32,7 +32,12 @@ open class MarkdownView: UIView {
   }
 
   public func load(markdown: String?, enableImage: Bool = true) {
-    guard let markdown = markdown else { return }
+    guard var markdown = markdown else { return }
+    // 如果是以分割线开始的markdown样式就会加载不出来分割线下边的东西
+    // 只有在分割线前边插入一个换行符或者空格(效果都是新增一行)
+    if markdown.hasPrefix("<hr>") {
+        markdown.insert(contentsOf: "<br>", at: markdown.startIndex)
+    }
 
     let bundle = Bundle(for: MarkdownView.self)
 


### PR DESCRIPTION
首行以分割线标签的markdown渲染不行，在分割线前边插入一个换行符或者空格(效果都是新增一行)